### PR TITLE
Don't set a HOOK script in the config

### DIFF
--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,3 +1,2 @@
-HOOK={{ dehydrated_config_dir }}/hook.sh
 WELLKNOWN={{ dehydrated_wellknown_dir }}
 CONTACT_EMAIL={{ dehydrated_contact_email }}


### PR DESCRIPTION
As there is no HOOK script, don't set it in the config, otherwise
dehydrated will fail.