### PR TITLE
Add openssl to required packages installed

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,11 +3,12 @@
   package_facts:
     manager: "auto"
 
-- name: Ensure git and curl are installed.
+- name: Ensure dependencies are installed.
   package:
     name:
       - git
       - curl
+      - openssl
     state: present
 
 - name: Clone dehydrated repo.


### PR DESCRIPTION
The dehydrated readme states this:

> It uses the openssl utility for everything related to actually
> handling keys and certificates, so you need to have that installed.

The openssl package is also one of just three dependencies of the
dehydrated package in the Debian project.