### PR TITLE
defaults: Bump version 0.7.0 -> 0.7.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-dehydrated_version: "v0.7.0"
+dehydrated_version: "v0.7.1"
 dehydrated_contact_email: ""
 dehydrated_location: "/usr/local/share/dehydrated"
 dehydrated_binary: "/usr/local/bin/dehydrated"


### PR DESCRIPTION
Release from 2022-10-31 … it's been a while already.

Link: https://github.com/dehydrated-io/dehydrated/releases/tag/v0.7.1