### PR TITLE
Flexible cert and base dir support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,16 @@ roles:
   - role: dehydrated
 ```
 
+### Migrate from Debian example
+
+If you used the Debian dehydrated package before, you can migrate to
+this role while keeping your account and cert data.  To mimic the
+directory structure used by Debian, configure the role like this:
+
+```yaml
+dehydrated_contact_email: "acme@example.com"
+dehydrated_config_dir: "/etc/dehydrated"
+dehydrated_base_dir: "/var/lib/dehydrated"
+dehydrated_certs_dir: "{{ dehydrated_base_dir }}/certs"
+dehydrated_wellknown_dir: "{{ dehydrated_base_dir }}/acme-challenges"
+```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ vars:
   dehydrated_location: "/usr/local/share/dehydrated"
   dehydrated_binary: "/usr/local/bin/dehydrated"
   dehydrated_config_dir: "/usr/local/etc/dehydrated"
+  dehydrated_base_dir: "{{ dehydrated_config_dir }}"
   dehydrated_certs_dir: "{{ dehydrated_config_dir }}/certs"
   dehydrated_wellknown_dir: "{{ dehydrated_config_dir }}/challenge"
   dehydrated_force_update: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ dehydrated_contact_email: ""
 dehydrated_location: "/usr/local/share/dehydrated"
 dehydrated_binary: "/usr/local/bin/dehydrated"
 dehydrated_config_dir: "/usr/local/etc/dehydrated"
+dehydrated_base_dir: "{{ dehydrated_config_dir }}"
 dehydrated_certs_dir: "{{ dehydrated_config_dir }}/certs"
 dehydrated_wellknown_dir: "{{ dehydrated_config_dir }}/challenge"
 dehydrated_domains:

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,3 +1,4 @@
 WELLKNOWN="{{ dehydrated_wellknown_dir }}"
 DOMAINS_TXT="{{ dehydrated_config_dir }}/domains.txt"
+CERTDIR="{{ dehydrated_certs_dir }}"
 CONTACT_EMAIL="{{ dehydrated_contact_email }}"

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,3 +1,4 @@
+BASEDIR="{{ dehydrated_base_dir }}"
 WELLKNOWN="{{ dehydrated_wellknown_dir }}"
 DOMAINS_TXT="{{ dehydrated_config_dir }}/domains.txt"
 CERTDIR="{{ dehydrated_certs_dir }}"

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,2 +1,3 @@
 WELLKNOWN="{{ dehydrated_wellknown_dir }}"
+DOMAINS_TXT="{{ dehydrated_config_dir }}/domains.txt"
 CONTACT_EMAIL="{{ dehydrated_contact_email }}"

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,2 +1,2 @@
-WELLKNOWN={{ dehydrated_wellknown_dir }}
-CONTACT_EMAIL={{ dehydrated_contact_email }}
+WELLKNOWN="{{ dehydrated_wellknown_dir }}"
+CONTACT_EMAIL="{{ dehydrated_contact_email }}"


### PR DESCRIPTION
When migrating from official Debian dehydrated package to this role, I wanted to keep the directory structure together with existing account and cert data.  First naïve try revealed #18, which is fixed by pinning down of the certs dir.  Flexible base dir support is added on top afterwards.