### PR TITLE
tasks: install: Also create base_dir

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,6 +29,12 @@
     state: directory
     mode: "0711"
 
+- name: Ensure base directory is present.
+  ansible.builtin.file:
+    path: "{{ dehydrated_base_dir }}"
+    state: directory
+    mode: "0711"
+
 - name: Ensure wellknown directory is present.
   ansible.builtin.file:
     path: "{{ dehydrated_wellknown_dir }}"


### PR DESCRIPTION
In case dehydrated_config_dir and dehydrated_base_dir are not the same (as default), dehydrated_base_dir should be created before dehydrated_certs_dir and dehydrated_wellknown_dir so the newly advised Debian compatible configuration example does not fail.

Leftover not pushed before hitting the PR button.

This should have been part of #19 already.