### PR TITLE
Fix linter warnings of types 'name' and 'risky-file-permissions'

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: dehydrated register
+- name: Dehydrated register
   ansible.builtin.command: "{{ dehydrated_binary }} --register --accept-terms"
 
-- name: dehydrated run
+- name: Dehydrated run
   ansible.builtin.command: "{{ dehydrated_binary }} --cron"
   when: dehydrated_force_update|default(False)|bool

--- a/tasks/domains.yml
+++ b/tasks/domains.yml
@@ -3,13 +3,14 @@
   ansible.builtin.file:
     name: "{{ dehydrated_certs_dir }}/{{ item.name }}"
     state: directory
+    mode: '0700'
   with_items: "{{ dehydrated_domains }}"
 
 - name: Render hook script templates.
   ansible.builtin.template:
     src: hook.sh.j2
     dest: "{{ dehydrated_certs_dir }}/{{ item.name }}/hook.sh"
-    mode: '755'
+    mode: '0755'
   with_items: "{{ dehydrated_domains }}"
 
 - name: Add configuration to call hook scripts
@@ -18,10 +19,12 @@
     regexp: "^HOOK="
     line: "HOOK={{ dehydrated_certs_dir }}/{{ item.name }}/hook.sh"
     create: true
+    mode: '0644'
   with_items: "{{ dehydrated_domains }}"
 
 - name: Ensure Domains are in domains.txt
   ansible.builtin.template:
     src: domains.txt.j2
     dest: "{{ dehydrated_config_dir }}/domains.txt"
+    mode: '0644'
   notify: dehydrated run

--- a/tasks/domains.yml
+++ b/tasks/domains.yml
@@ -27,4 +27,4 @@
     src: domains.txt.j2
     dest: "{{ dehydrated_config_dir }}/domains.txt"
     mode: '0644'
-  notify: dehydrated run
+  notify: Dehydrated run

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -56,10 +56,12 @@
   ansible.builtin.file:
     path: "{{ dehydrated_config_dir }}/domains.txt"
     state: touch
+    mode: '0644'
   when: not domains_txt.stat.exists
 
 - name: Ensure config is present.
   ansible.builtin.template:
     src: config.j2
     dest: "{{ dehydrated_config_dir }}/config"
+    mode: '0644'
   notify: dehydrated register

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -64,4 +64,4 @@
     src: config.j2
     dest: "{{ dehydrated_config_dir }}/config"
     mode: '0644'
-  notify: dehydrated register
+  notify: Dehydrated register

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
-- ansible.builtin.include_tasks: install.yml
-- ansible.builtin.include_tasks: domains.yml
+- name: Include tasks for installing dehydrated
+  ansible.builtin.include_tasks: install.yml
+
+- name: Include tasks for configuring domains
+  ansible.builtin.include_tasks: domains.yml
   when: dehydrated_domains is iterable


### PR DESCRIPTION
More easy to fix things to get those `ansible-lint` warnings down …