### PR TITLE
Introduce common hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,16 @@ vars:
   dehydrated_certs_dir: "{{ dehydrated_config_dir }}/certs"
   dehydrated_wellknown_dir: "{{ dehydrated_config_dir }}/challenge"
   dehydrated_force_update: True
+  dehydrated_common_hooks:
+    deploy_cert_hook: /usr/bin/systemctl reload nginx
   dehydrated_domains:
+    - name: example.org
+    - name: example.net
     - name: example.com
       alternate_names:
         - www.example.com
         - web.example.com
+      deploy_cert_hook:     # empty
       deploy_challenge_hook: printf 'server 127.0.0.1\nupdate add _acme-challenge.%s 300 IN TXT "%s"\nsend\n' "${DOMAIN}" "${TOKEN_VALUE}" | nsupdate -k /var/run/named/session.key
       clean_challenge_hook: printf 'server 127.0.0.1\nupdate delete _acme-challenge.%s TXT "%s"\nsend\n' "${DOMAIN}" "${TOKEN_VALUE}" | nsupdate -k /var/run/named/session.key
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ dehydrated_base_dir: "{{ dehydrated_config_dir }}"
 dehydrated_certs_dir: "{{ dehydrated_config_dir }}/certs"
 dehydrated_wellknown_dir: "{{ dehydrated_config_dir }}/challenge"
 dehydrated_domains:
+dehydrated_common_hooks:

--- a/templates/hook.sh.j2
+++ b/templates/hook.sh.j2
@@ -25,7 +25,7 @@ deploy_challenge() {
 
   # Simple example: Use nsupdate with local named
   # printf 'server 127.0.0.1\nupdate add _acme-challenge.%s 300 IN TXT "%s"\nsend\n' "${DOMAIN}" "${TOKEN_VALUE}" | nsupdate -k /var/run/named/session.key
-  {{ item.deploy_challenge_hook|default("") }}
+  {{ item.deploy_challenge_hook|default(dehydrated_common_hooks.deploy_challenge_hook|default("")) }}
 }
 
 clean_challenge() {
@@ -39,7 +39,7 @@ clean_challenge() {
 
   # Simple example: Use nsupdate with local named
   # printf 'server 127.0.0.1\nupdate delete _acme-challenge.%s TXT "%s"\nsend\n' "${DOMAIN}" "${TOKEN_VALUE}" | nsupdate -k /var/run/named/session.key
-  {{ item.clean_challenge_hook|default("") }}
+  {{ item.clean_challenge_hook|default(dehydrated_common_hooks.clean_challenge_hook|default("")) }}
 }
 
 sync_cert() {
@@ -66,7 +66,7 @@ sync_cert() {
 
   # Simple example: sync the files before symlinking them
   # sync "${KEYFILE}" "${CERTFILE}" "${FULLCHAINFILE}" "${CHAINFILE}" "${REQUESTFILE}"
-  {{ item.sync_cert_hook|default("") }}
+  {{ item.sync_cert_hook|default(dehydrated_common_hooks.sync_cert_hook|default("")) }}
 }
 
 deploy_cert() {
@@ -94,7 +94,7 @@ deploy_cert() {
   # Simple example: Copy file to nginx config
   # cp "${KEYFILE}" "${FULLCHAINFILE}" /etc/nginx/ssl/; chown -R nginx: /etc/nginx/ssl
   # systemctl reload nginx
-  {{ item.deploy_cert_hook|default("") }}
+  {{ item.deploy_cert_hook|default(dehydrated_common_hooks.deploy_cert_hook|default("")) }}
 }
 
 deploy_ocsp() {
@@ -116,7 +116,7 @@ deploy_ocsp() {
   # Simple example: Copy file to nginx config
   # cp "${OCSPFILE}" /etc/nginx/ssl/; chown -R nginx: /etc/nginx/ssl
   # systemctl reload nginx
-  {{ item.deploy_ocsp_hook|default("") }}
+  {{ item.deploy_ocsp_hook|default(dehydrated_common_hooks.deploy_ocsp_hook|default("")) }}
 }
 
 
@@ -138,7 +138,7 @@ unchanged_cert() {
   #   The path of the file containing the full certificate chain.
   # - CHAINFILE
   #   The path of the file containing the intermediate certificate(s).
-  {{ item.unchanged_cert_hook|default("") }}
+  {{ item.unchanged_cert_hook|default(dehydrated_common_hooks.unchanged_cert_hook|default("")) }}
 }
 
 invalid_challenge() {
@@ -156,7 +156,7 @@ invalid_challenge() {
 
   # Simple example: Send mail to root
   # printf "Subject: Validation of ${DOMAIN} failed!\n\nOh noez!" | sendmail root
-  {{ item.invalid_challenge_hook|default("") }}
+  {{ item.invalid_challenge_hook|default(dehydrated_common_hooks.invalid_challenge_hook|default("")) }}
 }
 
 request_failure() {
@@ -179,7 +179,7 @@ request_failure() {
 
   # Simple example: Send mail to root
   # printf "Subject: HTTP request failed failed!\n\nA http request failed with status ${STATUSCODE}!" | sendmail root
-  {{ item.request_failure_hook|default("") }}
+  {{ item.request_failure_hook|default(dehydrated_common_hooks.request_failure_hook|default("")) }}
 }
 
 generate_csr() {
@@ -205,13 +205,13 @@ generate_csr() {
   # if [ -e "${CERTDIR}/pre-generated.csr" ]; then
   #   cat "${CERTDIR}/pre-generated.csr"
   # fi
-  {{ item.generate_csr_hook|default("") }}
+  {{ item.generate_csr_hook|default(dehydrated_common_hooks.generate_csr_hook|default("")) }}
 }
 
 startup_hook() {
   # This hook is called before the cron command to do some initial tasks
   # (e.g. starting a webserver).
-  {{ item.startup_hook|default("") }}
+  {{ item.startup_hook|default(dehydrated_common_hooks.startup_hook|default("")) }}
   :
 }
 
@@ -224,7 +224,7 @@ exit_hook() {
   # Parameters:
   # - ERROR
   #   Contains error message if dehydrated exits with error
-  {{ item.exit_hook|default("") }}
+  {{ item.exit_hook|default(dehydrated_common_hooks.exit_hook|default("")) }}
 }
 
 HANDLER="$1"; shift


### PR DESCRIPTION
In playbooks with many domains hooks might be identical for almost all domains and needed to be repeated over and over again.  Now you can set such hooks in one common place.  Domains which should not get this hook can be excluded by setting an empty hook (or use "true" (with quotes!) or "/usr/bin/true" instead).  Logic is like this:

if domain specific hook is set: use that
else if common hook is set: use that
else: use nothing

Example diff of a playbook:

```diff
diff -r a696111b34bb host-miraculix.yml
--- a/host-miraculix.yml        Tue May 27 23:10:52 2025 +0200
+++ b/host-miraculix.yml        Wed May 28 09:47:03 2025 +0200
@@ -14,16 +14,16 @@
         state: absent

   vars:
+    dehydrated_common_hooks:
+      deploy_cert_hook: "systemctl reload nginx"
     dehydrated_domains:
       - name: "{{ esphome_domain_name }}"
+        deploy_cert_hook:
       - name: "{{ firefly_domain_name }}"
 #        alternate_names:
 #          - "www.{{ firefly_domain_name }}"
-        deploy_cert_hook: "systemctl reload nginx"
       - name: "sql.{{ firefly_domain_name }}"
-        deploy_cert_hook: "systemctl reload nginx"
       - name: "{{ influx_domain_name }}"
-        deploy_cert_hook: "systemctl reload nginx"
       - name: "{{ xmpp_domain_name }}"
         deploy_cert_hook: "docker exec prosody prosodyctl --root cert import ${DOMAIN} {{ dehydrated_certs_dir }}"
     nginx_sites:
```

Suggested-by: @penguineer 
Fixes: #7